### PR TITLE
[Feature] allow more corner cases for the component syntax

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -21,9 +21,9 @@ I try to make the syntax compatible with `Jinja2`.
 - [ ] template rich printing
 - [x] implement component syntax `{% Component * arg1 arg2 kwarg1=1 kwarg2=2 **kwargs %}`
 - [ ] allow more corner cases for the component syntax
-  - [ ] `{% Componnet arg=" * " %}`
-  - [ ] `{% Componnet arg = " * " %}`
-  - [ ] `{% Componnet arg = await f()`
+  - [x] `{% Component arg=" * " %}`
+  - [x] `{% Component arg = " * " %}`
+  - [ ] `{% Component arg = await f()`
 - [ ] if the outer context is a `defaultdict`, the context passing to component should be?
   - or maybe this should be determined by the component itself
   - because a component could be a `Node` and a `Node` can have preprocesses

--- a/python/promplate/prompt/template.py
+++ b/python/promplate/prompt/template.py
@@ -2,6 +2,7 @@ from copy import copy
 from functools import cached_property
 from pathlib import Path
 from typing import Any, Protocol
+from shlex import split
 
 from .builder import *
 from .utils import *
@@ -82,11 +83,20 @@ class TemplateCore(AutoNaming):
     @staticmethod
     def _make_context(text: str):
         pairs = []
-        for token in text.split(" ")[1:]:
+        tokens = split(text)
+        for i, token in enumerate(tokens):
+            if token == "=":
+                assert 0 < i < len(tokens) - 1
+                tokens[i-1] = tokens[i-1] + "=" + tokens[i+1]
+                tokens[i] = ""
+                tokens[i+1] = ""
+        for token in tokens[1:]:
             if token == "*":
                 pairs.append("**locals()")
             elif "=" in token or token.startswith("**"):
                 pairs.append(token)
+            elif token == "":
+                pass
             else:
                 pairs.append(f"{token}={token}")
 

--- a/python/promplate/prompt/template.py
+++ b/python/promplate/prompt/template.py
@@ -81,21 +81,9 @@ class TemplateCore(AutoNaming):
 
     @staticmethod
     def _make_context(text: str):
-        pairs = []
         text = text.strip()
-        tokens = parse_comma_sep_list(text.removeprefix(text.split(" ")[0]))
-
-        for token in tokens:
-            if token == "*":
-                pairs.append("**locals()")
-            elif "=" in token or token.startswith("**"):
-                pairs.append(token)
-            elif token == "":
-                pass
-            else:
-                pairs.append(f"{token}={token}")
-
-        return f"dict({', '.join(pairs)})"
+        args = text.removeprefix(text.split(" ")[0])
+        return f"dict({args})"
 
     def compile(self, sync=True):
         self._builder = get_base_builder(sync)

--- a/python/promplate/prompt/template.py
+++ b/python/promplate/prompt/template.py
@@ -2,7 +2,6 @@ from copy import copy
 from functools import cached_property
 from pathlib import Path
 from typing import Any, Protocol
-from shlex import split
 
 from .builder import *
 from .utils import *
@@ -83,22 +82,10 @@ class TemplateCore(AutoNaming):
     @staticmethod
     def _make_context(text: str):
         pairs = []
-        tokens = split(text)
-        for i, token in enumerate(tokens):
-            if token == "=":
-                assert 0 < i < len(tokens) - 1
-                tokens[i-1] = tokens[i-1] + "=" + tokens[i+1]
-                tokens[i] = ""
-                tokens[i+1] = ""
-            elif token.endswith("="):
-                assert i < len(tokens) - 1
-                tokens[i] = tokens[i] + tokens[i+1]
-                tokens[i+1] = ""
-            elif token.startswith("="):
-                assert i > 0
-                tokens[i-1] = tokens[i-1] + tokens[i]
-                tokens[i] = ""
-        for token in tokens[1:]:
+        text = text.strip()
+        tokens = parse_comma_sep_list(text.removeprefix(text.split(" ")[0]))
+
+        for token in tokens:
             if token == "*":
                 pairs.append("**locals()")
             elif "=" in token or token.startswith("**"):

--- a/python/promplate/prompt/template.py
+++ b/python/promplate/prompt/template.py
@@ -90,6 +90,14 @@ class TemplateCore(AutoNaming):
                 tokens[i-1] = tokens[i-1] + "=" + tokens[i+1]
                 tokens[i] = ""
                 tokens[i+1] = ""
+            elif token.endswith("="):
+                assert i < len(tokens) - 1
+                tokens[i] = tokens[i] + tokens[i+1]
+                tokens[i+1] = ""
+            elif token.startswith("="):
+                assert i > 0
+                tokens[i-1] = tokens[i-1] + tokens[i]
+                tokens[i] = ""
         for token in tokens[1:]:
             if token == "*":
                 pairs.append("**locals()")

--- a/python/promplate/prompt/utils.py
+++ b/python/promplate/prompt/utils.py
@@ -1,30 +1,16 @@
 from functools import cached_property
 from inspect import currentframe
 from re import compile
-from pyparsing import quotedString, originalTextFor, OneOrMore, Word, printables, nestedExpr, delimitedList
 
 split_template_tokens = compile(
     r"(\s{%-.*?-%}\s|\s{{-.*?-}}\s|\s{#-.*?-#}\s|\s{%-.*?%}|\s{{-.*?}}|\s{#-.*?#}|{%.*?-%}\s|{{.*?-}}\s|{#.*?-#}\s|{%.*?%}|{{.*?}}|{#.*?#})"
 ).split
 
-comma_sep_list = delimitedList(
-    (quotedString | originalTextFor(
-        OneOrMore(
-            Word(printables, excludeChars="()[]{},")
-            | nestedExpr("(", ")")
-            | nestedExpr("[", "]")
-            | nestedExpr("{", "}")
-        )
-    ))
-)
 
 var_name_checker = compile(r"[_a-zA-Z]\w*$")
 
 is_message_start = compile(r"<\|\s?(user|system|assistant)\s?(\w{1,64})?\s?\|>")
 
-
-def parse_comma_sep_list(text: str) -> list:
-    return comma_sep_list.parseString(text).asList()
 
 def is_not_valid(name: str):
     return not var_name_checker.match(name)

--- a/python/promplate/prompt/utils.py
+++ b/python/promplate/prompt/utils.py
@@ -1,16 +1,30 @@
 from functools import cached_property
 from inspect import currentframe
 from re import compile
+from pyparsing import quotedString, originalTextFor, OneOrMore, Word, printables, nestedExpr, delimitedList
 
 split_template_tokens = compile(
     r"(\s{%-.*?-%}\s|\s{{-.*?-}}\s|\s{#-.*?-#}\s|\s{%-.*?%}|\s{{-.*?}}|\s{#-.*?#}|{%.*?-%}\s|{{.*?-}}\s|{#.*?-#}\s|{%.*?%}|{{.*?}}|{#.*?#})"
 ).split
 
+comma_sep_list = delimitedList(
+    (quotedString | originalTextFor(
+        OneOrMore(
+            Word(printables, excludeChars="()[]{},")
+            | nestedExpr("(", ")")
+            | nestedExpr("[", "]")
+            | nestedExpr("{", "}")
+        )
+    ))
+)
 
 var_name_checker = compile(r"[_a-zA-Z]\w*$")
 
 is_message_start = compile(r"<\|\s?(user|system|assistant)\s?(\w{1,64})?\s?\|>")
 
+
+def parse_comma_sep_list(text: str) -> list:
+    return comma_sep_list.parseString(text).asList()
 
 def is_not_valid(name: str):
     return not var_name_checker.match(name)


### PR DESCRIPTION
Add support: allow more corner cases for the component syntax

**Update:** Now we directly use the Python dictionary format for component syntax, thus we need a new version number, since some grammar is no longer supported.