### PR TITLE
Add static-type-checking workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,3 +33,7 @@ jobs:
         working-directory: python
         run: |
           poetry run test
+      - name: Check Types
+        working-directory: python
+        run: |
+          poetry run npx -y pyright

--- a/python/promplate/chain/node.py
+++ b/python/promplate/chain/node.py
@@ -267,7 +267,7 @@ class Chain(Interruptable):
 
     def _run(self, context, /, complete=None):
         for node in self.nodes:
-            context = node.run(context, self.complete or complete)
+            context = node.run(context, self.complete or complete)  # type: ignore
 
         return context
 

--- a/python/promplate/prompt/chat.py
+++ b/python/promplate/prompt/chat.py
@@ -8,7 +8,7 @@ Role = Literal["user", "assistant", "system"]
 if version_info >= (3, 11):
     from typing import NotRequired, TypedDict
 
-    class Message(TypedDict):
+    class Message(TypedDict):  # type: ignore
         role: Role
         content: str
         name: NotRequired[str]


### PR DESCRIPTION
feat: add static-type-checking workflow
fix: tolerate an ambiguous type and an obscured declaration