### PR TITLE
Merge `locals()` with `globals()` for context in Python 3.13

### DIFF
--- a/python/promplate/prompt/template.py
+++ b/python/promplate/prompt/template.py
@@ -3,6 +3,7 @@ from collections import ChainMap
 from functools import cached_property, partial
 from pathlib import Path
 from sys import path as sys_path
+from sys import version_info
 from textwrap import dedent
 from typing import TYPE_CHECKING, Any, Literal, Protocol
 
@@ -87,7 +88,8 @@ class TemplateCore(AutoNaming):
     @staticmethod
     def _make_context(text: str):
         """generate context parameter if specified otherwise use locals() by default"""
-
+        if version_info >= (3, 13):
+            return f"globals() | locals() | dict({text[text.index(' ') + 1:]})" if " " in text else "globals() | locals()"
         return f"locals() | dict({text[text.index(' ') + 1:]})" if " " in text else "locals()"
 
     def compile(self, sync=True, indent_str="\t"):

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "promplate"
-version = "0.3.4.9"
+version = "0.3.4.10"
 description = "Prompt engineering framework for humans"
 homepage = "https://promplate.dev/"
 documentation = "https://docs.py.promplate.dev/"

--- a/python/tests/test_template.py
+++ b/python/tests/test_template.py
@@ -377,6 +377,10 @@ def test_components_context():
     assert Template("{% a b=1, c=2 %}").render({"a": Template("{{ b }}{{ c }}{{ d }}"), "d": 3}) == "123"
 
 
+def test_components_in_for_loop():
+    assert Template("{% for i in '123' %}{% a %}{% endfor %}").render({"a": Template("{{ i }}")}) == "123"
+
+
 def test_else_tag_in_for_loop():
     render_assert("{% for i in '123' %}{{ i }}{% else %}4{% endfor %}", None, "1234")
 

--- a/python/tests/test_utils.py
+++ b/python/tests/test_utils.py
@@ -19,6 +19,7 @@ async def test_accumulate():
     assert await anext(it) == "a"
     assert await anext(it) == "ab"
     assert await anext(it) == "abc"
+    await it.aclose()
 
 
 async def test_accumulate_empty():


### PR DESCRIPTION
- Fixes #13

## Summary by Sourcery

Fix context generation by merging `locals()` with `globals()` for Python 3.13 and above, ensuring correct context forwarding.

Bug Fixes:
- Fix context generation to correctly merge `locals()` with `globals()` when Python version is 3.13 or higher.